### PR TITLE
update item and versioning 

### DIFF
--- a/aurelia-app/src/app.html
+++ b/aurelia-app/src/app.html
@@ -10,8 +10,8 @@
     <!-- List of existing items -->
     <section class="app-section--items-list">
       <h2>Item list</h2>
-      <item-card item.bind="item"
-                 repeat.for="item of items"></item-card>
+      <item-card item.bind="item" repeat.for="item of items" versions.bind="getItemVersions" update.bind="updateItem">
+      </item-card>
     </section>
   </main>
 </template>

--- a/aurelia-app/src/app.ts
+++ b/aurelia-app/src/app.ts
@@ -19,6 +19,7 @@ export class App {
    */
   public items: Api.Item[];
 
+  public versions: Api.ItemVersion[];
   /**
    * @memberof App
    * @lifecycle
@@ -49,5 +50,34 @@ export class App {
   addItem = async (item: Api.Item): Promise<void> => {
     await Api.postItem(item);
     this.getAllItems();
+  }
+
+  /**
+   * update the item
+   * 
+   * Passed as function reference to custom element
+   *   and thus needs to be an arrow function to bind 'this' *
+   *
+   * @param {Api.Item} item
+   * @memberof App
+   */
+  updateItem = async (item: Api.Item): Promise<void> => {
+    const updatedItem = await Api.putItem(item);
+    const itemId = this.items.findIndex(it => it.id == updatedItem.id);
+    this.items = [...this.items];
+    this.items[itemId] = updatedItem;
+  }
+
+  /**
+   * get all versions of item
+   * 
+   * Passed as function reference to custom element
+   *   and thus needs to be an arrow function to bind 'this' *
+   *
+   * @param {string} itemId
+   * @memberof App
+   */
+  async getItemVersions(itemId: string): Promise<Api.ItemVersion[]> {
+    return await Api.getItemVersions(itemId);
   }
 }

--- a/aurelia-app/src/resources/add-items-dialog/add-items-dialog.html
+++ b/aurelia-app/src/resources/add-items-dialog/add-items-dialog.html
@@ -1,47 +1,34 @@
 <template>
   <div>
-    <h2>Add Item to the List</h2>
+    <h2> ${isEditMode? "Edit Item":"Add Item to the List"}</h2>
 
     <div class="app--add-item-form">
       <!-- item name input -->
       <section class="app-section--item-name">
         <label>
           Item Name:
-          <input required
-                 type="text"
-                 value.two-way="itemName"/>
+          <input required type="text" value.two-way="itemName" />
         </label>
       </section>
       <section class="app-section--item-attributes">
         <div class="app--add-attributes-list">
           <!-- list of attribute inputs -->
-          <div
-            class="app--add-attributes-list-item"
-            repeat.for="attr of attributes"
-          >
+          <div class="app--add-attributes-list-item" repeat.for="attr of attributes">
             <label>
               Key:
-              <input required
-                     type="text"
-                     value.two-way="attr[0]"/>
+              <input required type="text" value.two-way="attr[0]" />
             </label>
 
             <label>
               Value:
-              <input required
-                     type="text"
-                     value.two-way="attr[1]"/>
+              <input required type="text" value.two-way="attr[1]" />
             </label>
-            <button
-              click.delegate="removeAttribute($index)"
-            >
+            <button click.delegate="removeAttribute($index)">
               Remove Attribute
             </button>
           </div>
 
-          <button
-            click.delegate="addEmptyAttribute()"
-          >
+          <button click.delegate="addEmptyAttribute()">
             Add Attribute
           </button>
         </div>
@@ -50,10 +37,12 @@
 
     <!-- Save and Cancel buttons-->
     <div>
-      <button click.delegate="addItem()"
-              disabled.bind="!itemName || !validateAttributes"
-      >
-        Add
+      <button click.delegate="saveItem()" disabled.bind="!itemName || !validateAttributes">
+        ${isEditMode? "Save":"Add"}
+      </button>
+
+      <button if.bind="isEditMode" click.delegate="cancel()">
+        Cancel
       </button>
     </div>
   </div>

--- a/aurelia-app/src/resources/add-items-dialog/add-items-dialog.ts
+++ b/aurelia-app/src/resources/add-items-dialog/add-items-dialog.ts
@@ -14,6 +14,41 @@ export class AddItemsDialog {
   @bindable save: (item: Api.Item) => Promise<void>;
 
   /**
+   * Bound function reference to call to update item.
+   *
+   * @memberof AddItemsDialog
+   * @bindable
+   */
+  @bindable update: (item: Api.Item) => Promise<void>;
+
+  /**
+   * Bound function reference to call to cancel edition
+   *
+   * @memberof AddItemsDialog
+   * @bindable
+   */
+  @bindable oncancel: () => void;
+
+  /**
+   * The current item
+   *
+   * @type {Item}
+   * @memberof AddItemsDialog
+   * @bindable
+   */
+  @bindable item: Api.Item;
+
+
+  /**
+   * To show whether form is in edit mode or add mode
+   *
+   * @type {boolean}
+   * @memberof AddItemsDialog
+   * @bindable
+   */
+  @bindable isEditMode: boolean;
+
+  /**
    * Input element value of the item name
    *
    * @type {string}
@@ -31,6 +66,20 @@ export class AddItemsDialog {
   public attributes: Array<Array<string>> = new Array();
 
   /**
+   * @memberof AddItemsDialog
+   * @lifecycle
+   */
+  bind() {
+    if (this.item) {
+      this.itemName = this.item.name;
+      this.attributes = Object.entries(this.item.attributes);
+      this.isEditMode = true;
+    } else {
+      this.isEditMode = false;
+    }
+  }
+
+  /**
    * Add empty attribute to attributes array
    *
    * @memberof AddItemsDialog
@@ -45,6 +94,18 @@ export class AddItemsDialog {
   */
   removeAttribute(index) {
     this.attributes.splice(index, 1);
+  }
+
+  /**
+  * Updates item if it already exist, otherwise adds item
+  *
+  */
+  saveItem() {
+    if (this.isEditMode) {
+      this.updateItem();
+    } else {
+      this.addItem();
+    }
   }
 
   /**
@@ -69,6 +130,30 @@ export class AddItemsDialog {
   resetDialog() {
     this.itemName = '';
     this.attributes = new Array();
+  }
+
+  /**
+   * update current item
+   *
+   * @return {*}  {Promise<void>}
+   * @memberof AddItemsDialog
+   */
+  async updateItem(): Promise<void> {
+    void await this.update({
+      id: this.item.id,
+      name: this.itemName,
+      attributes: Object.fromEntries(this.attributes)
+    });
+    this.resetDialog();
+  }
+
+  /**
+   * cancel edition
+   *
+   * @memberof AddItemsDialog
+   */
+  cancel() {
+    this.oncancel();
   }
 
   /**

--- a/aurelia-app/src/resources/api/items.ts
+++ b/aurelia-app/src/resources/api/items.ts
@@ -1,8 +1,14 @@
 const itemsEndpoint = '/items';
 
 export interface Item {
+  id?: string;
   name: string;
   attributes: { [key: string]: string };
+}
+
+export interface ItemVersion extends Item {
+  versionDate: Date;
+  versionNumber: number;
 }
 
 /**
@@ -47,3 +53,49 @@ export async function postItem(item: Item): Promise<Item> {
 
   return response.json();
 }
+
+/**
+ * Update existing item. 
+ *
+ * @export
+ * @param {Item} item The item to update
+ * @return {Promise<Item>} The updated item
+ */
+export async function putItem(item: Item): Promise<Item> {
+  const itemUrl = `${itemsEndpoint}/${item.id}`
+  const response = await fetch(
+    itemUrl,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(item),
+    }
+  );
+
+  return response.json();
+}
+
+/**
+ * Get all versions of item.
+ *
+ * @export
+ * @param {string} itemId of item
+ * @return {Promise<ItemVersion[]>} The stored versions of item
+ */
+export async function getItemVersions(itemId: string): Promise<ItemVersion[]> {
+  const itemUrl = `${itemsEndpoint}/${itemId}/versions`
+  const response = await fetch(
+    itemUrl,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+    }
+  );
+
+  return response.json();
+}
+

--- a/aurelia-app/src/resources/index.ts
+++ b/aurelia-app/src/resources/index.ts
@@ -5,5 +5,6 @@ export function configure(config: FrameworkConfiguration) {
   config.globalResources([
     PLATFORM.moduleName('./add-items-dialog/add-items-dialog'),
     PLATFORM.moduleName('./item-card/item-card'),
+    PLATFORM.moduleName('./item-version-card/item-version-card'),
   ]);
 }

--- a/aurelia-app/src/resources/item-card/item-card.html
+++ b/aurelia-app/src/resources/item-card/item-card.html
@@ -1,6 +1,25 @@
 <template>
-  <article>
-    <h3>${item.name}</h3>
-    <span repeat.for="attr of attributes"><b>${attr[0]}:</b> ${attr[1]} </span>
-  </article>
+  <section if.bind="!isEditMode">
+    <article>
+      <h3>${item.name}</h3>
+      <span repeat.for="attr of attributes"><b>${attr[0]}:</b> ${attr[1]} </span>
+    </article>
+    <button click.delegate="onStartEdit()">
+      Update Item
+    </button>
+    <button click.delegate="onToggleVersions()">
+      ${showVersions? "Hide Version" : "Show Versions"}
+    </button>
+    </article>
+  </section>
+  <!-- Update item -->
+  <section else>
+    <add-items-dialog update.bind="update" item.bind="item" save.bind="update" oncancel.bind="onCancelEdit">
+    </add-items-dialog>
+  </section>
+  <!-- Versions of item -->
+  <section if.bind="showVersions">
+    <item-version-card version.bind="version" repeat.for="version of itemVersions">
+    </item-version-card>
+  </section>
 </template>

--- a/aurelia-app/src/resources/item-card/item-card.scss
+++ b/aurelia-app/src/resources/item-card/item-card.scss
@@ -1,6 +1,6 @@
 item-card {
   display: block;
-  padding: 0 10px 10px 10px;
+  padding: 10px;
   margin-bottom: 10px;
   border: 1px solid gray;
   background-color: #fafafa;

--- a/aurelia-app/src/resources/item-card/item-card.ts
+++ b/aurelia-app/src/resources/item-card/item-card.ts
@@ -1,5 +1,5 @@
 import { bindable } from 'aurelia-framework';
-import { Item } from '../api/items';
+import { Item, ItemVersion } from '../api/items';
 
 import './item-card.scss';
 
@@ -12,13 +12,56 @@ import './item-card.scss';
  */
 export class ItemCard {
   /**
-   * The item to display
+   * The item
    *
    * @type {Item}
    * @memberof ItemCard
    * @bindable
    */
   @bindable item: Item;
+
+  /**
+   * The item versions
+   *
+   * @type {ItemVersion[]}
+   * @memberof ItemCard
+   * @bindable
+   */
+  @bindable itemVersions: ItemVersion[] = [];
+
+  /**
+   * Edit mode 
+   *
+   * @type {boolean}
+   * @memberof ItemCard
+   * @bindable
+   */
+  @bindable isEditMode: boolean;
+
+  /**
+   * Version mode 
+   *
+   * @type {boolean}
+   * @memberof ItemCard
+   * @bindable
+   */
+  @bindable showVersions: boolean;
+
+  /**
+   * Bound function reference to call to update item.
+   *
+   * @memberof ItemCard
+   * @bindable
+   */
+  @bindable update: (item: Item) => Promise<void>;
+
+  /**
+   * Bound function reference to call to get all versions of item.
+   *
+   * @memberof ItemCard
+   * @bindable
+   */
+  @bindable versions: (itemId: string) => Promise<ItemVersion[]>;
 
   /**
    * Array of this item's attributes
@@ -43,5 +86,37 @@ export class ItemCard {
    */
   convertItemsObjectToArray() {
     this.attributes = Object.entries(this.item.attributes);
+  }
+
+  /**
+   * Swith to Edit mode
+   *
+   * @memberof ItemCardEditable
+   */
+  onStartEdit(): void {
+    this.isEditMode = true;
+  }
+
+  /**
+   * Swith to View mode
+   *
+   * @memberof ItemCardEditable
+   */
+  onCancelEdit = () => {
+    this.isEditMode = false;
+  }
+
+  /**
+   * Toggle item versions
+   *
+   * @memberof ItemCardEditable
+   */
+  onToggleVersions = async (): Promise<void> => {
+    if (this.showVersions) {
+      this.showVersions = false;
+    } else {
+      this.itemVersions = await this.versions(this.item.id);
+      this.showVersions = true;
+    }
   }
 }

--- a/aurelia-app/src/resources/item-version-card/item-version-card.html
+++ b/aurelia-app/src/resources/item-version-card/item-version-card.html
@@ -1,0 +1,14 @@
+<template>
+  <article>
+
+    <h3>Version number: ${version.versionNumber}</h3>
+    <h4>Date: ${version.versionDate.substring(0, 10)} Time: ${version.versionDate.substring(11, 19)}</h4>
+    <h4>Name: ${version.name}</h4>
+
+    <b>Attributes:</b>
+    <ul repeat.for="attr of attributes">
+      <li> ${attr[0]}: ${attr[1]} </li>
+    </ul>
+
+  </article>
+</template>

--- a/aurelia-app/src/resources/item-version-card/item-version-card.scss
+++ b/aurelia-app/src/resources/item-version-card/item-version-card.scss
@@ -1,0 +1,7 @@
+item-version-card {
+  display: block;
+  padding: 0 10px 10px 10px;
+  margin: 10px;
+  border: 1px solid gray;
+  background-color: #ddb7da;
+}

--- a/aurelia-app/src/resources/item-version-card/item-version-card.ts
+++ b/aurelia-app/src/resources/item-version-card/item-version-card.ts
@@ -1,0 +1,51 @@
+import { bindable } from 'aurelia-framework';
+import * as Api from '../api/items';
+
+import './item-version-card.scss';
+
+/**
+ * Custom element to display item version
+ *
+ * @export
+ * @class ItemVersionCard
+ * @customElement
+ */
+
+export class ItemVersionCard {
+
+  /**
+   * The version to display
+   *
+   * @type {ItemVersion}
+   * @memberof ItemVersionCard
+   * @bindable
+   */
+  @bindable version: Api.ItemVersion;
+
+
+  /**
+   * Array of this version's attributes
+   *
+   * @type {Array<Array<string>>}
+   * @memberof ItemVersionCard
+   */
+  public attributes: Array<Array<string>>;
+
+  /**
+   * @memberof ItemVersionCard
+   * @lifecycle
+   */
+  bind() {
+    this.convertItemsObjectToArray();
+  }
+
+  /**
+   * Convert items object to iterable array, so that in can be used with repeat.for in the view
+   *
+   * @memberof ItemVersionCard
+   */
+  convertItemsObjectToArray() {
+    this.attributes = Object.entries(this.version.attributes);
+  }
+
+}

--- a/src/main/java/com/labregister/api/items/controller/ItemController.java
+++ b/src/main/java/com/labregister/api/items/controller/ItemController.java
@@ -3,10 +3,14 @@ package com.labregister.api.items.controller;
 import com.google.common.base.Preconditions;
 import com.labregister.api.core.creation.EntityCreatedResponse;
 import com.labregister.api.items.domain.Item;
+import com.labregister.api.items.domain.ItemVersion;
 import com.labregister.api.items.service.ItemService;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriTemplate;
@@ -28,16 +32,28 @@ public class ItemController {
 		this.itemService = itemService;
 	}
 
-	@RequestMapping(value = "/items", method = RequestMethod.GET)
+	@GetMapping(value = "/items")
 	@ResponseBody
 	public Collection<Item> getItems() {
 		return itemService.getItems();
 	}
 
-	@RequestMapping(value = "/items", method = RequestMethod.POST)
+	@PostMapping(value = "/items")
 	public EntityCreatedResponse<Item> createItem(@RequestBody Item request) {
 		Item created = itemService.createItem(request);
 		return new EntityCreatedResponse<>(created, getItemLocation(created));
+	}
+
+	@PutMapping(value = "/items/{itemId}")
+	@ResponseBody
+	public Item updateItem(@PathVariable String itemId, @RequestBody Item request) {
+		return itemService.updateItem(itemId, request);
+	}
+
+	@GetMapping(value = "/items/{itemId}/versions")
+	@ResponseBody
+	public Collection<ItemVersion> getItemVersions(@PathVariable String itemId) {
+		return itemService.getItemVersions(itemId);
 	}
 
 	private URI getItemLocation(Item item) {

--- a/src/main/java/com/labregister/api/items/domain/Item.java
+++ b/src/main/java/com/labregister/api/items/domain/Item.java
@@ -1,11 +1,10 @@
 package com.labregister.api.items.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.labregister.api.core.validation.Entity;
 
 import javax.validation.constraints.NotBlank;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Simple Item resource to demonstrate Labregister functionality
@@ -20,6 +19,13 @@ public class Item implements Entity, Comparable<Item> {
 	private Map<@NotBlank String, @NotBlank String> attributes = new HashMap<>();
 
 	private Date creationDate;
+
+	private Date lastUpdateDate;
+
+	private int versionNumber = 0;
+
+	@JsonIgnore
+	private final Deque<ItemVersion> versions = new LinkedList<>();
 
 	public Item() {
 		// needed for JSON deserialization
@@ -65,10 +71,42 @@ public class Item implements Entity, Comparable<Item> {
 
 	public void setCreationDate(Date creationDate) {
 		this.creationDate = creationDate;
+		this.lastUpdateDate = creationDate;
+	}
+
+	public List<ItemVersion> getVersions() {
+		return new ArrayList<>(versions);
+	}
+
+	public Date getLastUpdateDate() {
+		return lastUpdateDate;
+	}
+
+	public void setLastUpdateDate(Date lastUpdateDate) {
+		this.lastUpdateDate = lastUpdateDate;
+	}
+
+	public void createVersion() {
+		versionNumber++;
+		versions.push(new ItemVersion(this));
+	}
+
+	public int getVersionNumber() {
+		return versionNumber;
 	}
 
 	@Override
 	public int compareTo(Item item) {
 		return item.getCreationDate().compareTo(this.getCreationDate());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Item item = (Item) o;
+		return id.equals(item.id) &&
+				name.equals(item.name) &&
+				attributes.equals(item.attributes);
 	}
 }

--- a/src/main/java/com/labregister/api/items/domain/Item.java
+++ b/src/main/java/com/labregister/api/items/domain/Item.java
@@ -87,7 +87,9 @@ public class Item implements Entity, Comparable<Item> {
 	}
 
 	public void createVersion() {
-		versionNumber++;
+		synchronized (this) {
+			versionNumber++;
+		}
 		versions.push(new ItemVersion(this));
 	}
 

--- a/src/main/java/com/labregister/api/items/domain/ItemVersion.java
+++ b/src/main/java/com/labregister/api/items/domain/ItemVersion.java
@@ -1,0 +1,40 @@
+package com.labregister.api.items.domain;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ItemVersion {
+
+    private final int versionNumber;
+
+    private final String name;
+
+    private final Map<String, String> attributes;
+
+    private final Date versionDate;
+
+    public ItemVersion(Item item) {
+        this.versionNumber = item.getVersionNumber();
+        this.name = item.getName();
+        this.attributes = new HashMap<>(item.getAttributes());
+        this.versionDate = (Date) (item.getLastUpdateDate().clone());
+    }
+
+    public int getVersionNumber() {
+        return versionNumber;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, String> getAttributes() {
+        return new HashMap<>(attributes);
+    }
+
+    public Date getVersionDate() {
+        return (Date) versionDate.clone();
+    }
+
+}

--- a/src/main/java/com/labregister/api/items/service/ItemService.java
+++ b/src/main/java/com/labregister/api/items/service/ItemService.java
@@ -1,6 +1,7 @@
 package com.labregister.api.items.service;
 
 import com.labregister.api.items.domain.Item;
+import com.labregister.api.items.domain.ItemVersion;
 
 import java.util.List;
 
@@ -8,7 +9,11 @@ public interface ItemService {
 
 	Item createItem(Item item);
 
+	Item updateItem(String id, Item item);
+
 	List<Item> getItems();
+
+	List<ItemVersion> getItemVersions(String itemId);
 
 	void deleteAllItems();
 }

--- a/src/main/java/com/labregister/api/items/service/ItemServiceImpl.java
+++ b/src/main/java/com/labregister/api/items/service/ItemServiceImpl.java
@@ -1,25 +1,24 @@
 package com.labregister.api.items.service;
 
+import com.labregister.api.core.exception.ResourceNotFoundException;
 import com.labregister.api.core.validation.EntityValidator;
 import com.labregister.api.items.domain.Item;
+import com.labregister.api.items.domain.ItemVersion;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
-public class ItemServiceImpl implements ItemService {
+public final class ItemServiceImpl implements ItemService {
 
-	private List<Item> items;
+	private Map<String, Item> items;
 
 	private EntityValidator entityValidator;
 
 	public ItemServiceImpl(EntityValidator entityValidator) {
 		this.entityValidator = entityValidator;
-		this.items = new ArrayList<>();
+		this.items = new HashMap<>();
 	}
 
 	@Override
@@ -32,9 +31,7 @@ public class ItemServiceImpl implements ItemService {
 
 	@Override
 	public List<Item> getItems() {
-		return this.items.stream()
-		                 .sorted()
-		                 .collect(Collectors.toList());
+		return this.items.values().stream().sorted().collect(Collectors.toList());
 	}
 
 	@Override
@@ -42,8 +39,42 @@ public class ItemServiceImpl implements ItemService {
 		this.items.clear();
 	}
 
+	@Override
+	public Item updateItem(String id, Item request) {
+		entityValidator.validateUpdate(id, request);
+		Item previousItem = getItem(id);
+		if (isNewVersion(request)) {
+			previousItem.setName(request.getName());
+			previousItem.setAttributes(request.getAttributes());
+			previousItem.setLastUpdateDate(new Date());
+			return save(previousItem);
+		} else {
+			return previousItem;
+		}
+
+	}
+
+	@Override
+	public List<ItemVersion> getItemVersions(String itemId) {
+		return this.getItem(itemId).getVersions();
+	}
+
 	private Item save(Item item) {
-		this.items.add(item);
+		this.items.put(item.getId(), item);
+		item.createVersion();
 		return item;
+	}
+
+	private boolean isNewVersion(Item updatedItem) {
+		return !this.items.containsKey(updatedItem.getId())
+				|| !this.items.get(updatedItem.getId()).equals(updatedItem);
+	}
+
+	private Item getItem(String itemId) {
+		if (!items.containsKey(itemId)) {
+			throw new ResourceNotFoundException("ITEM NOT FOUND");
+		} else {
+			return items.get(itemId);
+		}
 	}
 }

--- a/src/test/java/com/labregister/api/items/ItemControllerTest.java
+++ b/src/test/java/com/labregister/api/items/ItemControllerTest.java
@@ -1,9 +1,11 @@
 package com.labregister.api.items;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.labregister.api.common.MVCIntegrationTest;
 import com.labregister.api.items.controller.ItemController;
 import com.labregister.api.items.domain.Item;
+import com.labregister.api.items.domain.ItemVersion;
 import com.labregister.api.items.service.ItemService;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,13 +16,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -48,27 +51,79 @@ public class ItemControllerTest extends MVCIntegrationTest {
 		}
 	}
 
+	static String asJsonString(final Object obj) {
+		try {
+			return new ObjectMapper().writeValueAsString(obj);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	@Test
 	public void POST_createsItemSuccessfully_WhenRequestValid() throws Exception {
 		Item item = ItemFactory.randomItem();
-		final String body = getItemBodyAsJSON(item);
+		final String body = getNewItemBodyAsJSON(item);
 
 		when(itemServiceMock.createItem(any())).thenReturn(item);
 
 		ResultActions actions = mockMvc.perform(post("/items").contentType(MediaType.APPLICATION_JSON)
-		                                                      .content(body))
-		                               .andExpect(status().isCreated());
+				.content(body))
+				.andExpect(status().isCreated());
 		assertItem("$", item, actions);
+	}
+
+	@Test
+	public void PUT_updateItemSuccessfully_WhenRequestValid() throws Exception {
+		Item item = ItemFactory.randomItem();
+		final String body = asJsonString(item);
+
+		when(itemServiceMock.updateItem(anyString(), any())).thenReturn(item);
+
+		ResultActions actions = mockMvc
+				.perform(put("/items/" + item.getId()).contentType(MediaType.APPLICATION_JSON)
+						.content(body))
+				.andExpect(status().isOk());
+
+		assertItem("$", item, actions);
+	}
+
+	@Test
+	public void GET_ItemVersions_ReturnsCorrectHeaderAndContent() throws Exception {
+		List<ItemVersion> items = ImmutableList
+				.of(ItemFactory.randomItem(), ItemFactory.randomItem(), ItemFactory.randomItem()).stream()
+				.map(ItemVersion::new).collect(Collectors.toList());
+
+		when(itemServiceMock.getItemVersions(anyString())).thenReturn(items);
+
+		final String ITEM_ID = "TEST-ID";
+
+		ResultActions actions = mockMvc.perform(get("/items/" + ITEM_ID + "/versions"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(3)));
+
+		for (int i = 0; i < items.size(); i++) {
+			ItemVersion itemVersion = items.get(i);
+			assertItemVersion("$.[" + i + "]", itemVersion, actions);
+		}
 	}
 
 	private void assertItem(String rootPath, Item item, ResultActions actions) throws Exception {
 		actions.andExpect(jsonPath(rootPath + ".id", is(item.getId())))
-		       .andExpect(jsonPath(rootPath + ".creationDate").exists())
-		       .andExpect(jsonPath(rootPath + ".name", is(item.getName())))
-		       .andExpect(jsonPath(rootPath + ".attributes").exists());
+				.andExpect(jsonPath(rootPath + ".creationDate").exists())
+				.andExpect(jsonPath(rootPath + ".name", is(item.getName())))
+				.andExpect(jsonPath(rootPath + ".attributes").exists())
+				.andExpect(jsonPath(rootPath + ".versionNumber").exists())
+				.andExpect(jsonPath(rootPath + ".lastUpdateDate").exists());
 	}
 
-	private String getItemBodyAsJSON(Item item) throws JSONException {
+	private void assertItemVersion(String rootPath, ItemVersion itemVersion, ResultActions actions) throws Exception {
+		actions.andExpect(jsonPath(rootPath + ".versionNumber", is(itemVersion.getVersionNumber())))
+				.andExpect(jsonPath(rootPath + ".versionDate").exists())
+				.andExpect(jsonPath(rootPath + ".name", is(itemVersion.getName())))
+				.andExpect(jsonPath(rootPath + ".attributes").exists());
+	}
+
+	private String getNewItemBodyAsJSON(Item item) throws JSONException {
 		JSONObject json = new JSONObject().put("name", item.getName());
 		return json.toString();
 	}

--- a/src/test/java/com/labregister/api/items/ItemServiceTest.java
+++ b/src/test/java/com/labregister/api/items/ItemServiceTest.java
@@ -2,16 +2,20 @@ package com.labregister.api.items;
 
 import com.google.common.collect.ImmutableMap;
 import com.labregister.api.core.exception.EntityValidationException;
+import com.labregister.api.core.exception.ResourceNotFoundException;
 import com.labregister.api.items.domain.Item;
+import com.labregister.api.items.domain.ItemVersion;
 import com.labregister.api.items.service.ItemService;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.List;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -67,6 +71,8 @@ public class ItemServiceTest {
 		Assert.assertEquals("pink", firstItemInList.getAttributes().get("color"));
 		Assert.assertNotNull(firstItemInList.getId());
 		Assert.assertNotNull(firstItemInList.getCreationDate());
+		Assert.assertEquals(firstItemInList.getCreationDate(), firstItemInList.getLastUpdateDate());
+		Assert.assertEquals(1, firstItemInList.getVersionNumber());
 		Item secondItemInList = items.get(1);
 		Assert.assertEquals("Item 2", secondItemInList.getName());
 		Assert.assertEquals("2020", secondItemInList.getAttributes().get("year"));
@@ -74,13 +80,196 @@ public class ItemServiceTest {
 		Assert.assertEquals("M", secondItemInList.getAttributes().get("size"));
 		Assert.assertNotNull(secondItemInList.getId());
 		Assert.assertNotNull(secondItemInList.getCreationDate());
+		Assert.assertEquals(secondItemInList.getCreationDate(), secondItemInList.getLastUpdateDate());
+		Assert.assertEquals(1, secondItemInList.getVersionNumber());
 		Item lastItemInList = items.get(2);
 		Assert.assertEquals("Item 1", lastItemInList.getName());
 		Assert.assertEquals("2019", lastItemInList.getAttributes().get("year"));
 		Assert.assertEquals("black", lastItemInList.getAttributes().get("color"));
 		Assert.assertEquals("S", lastItemInList.getAttributes().get("size"));
-		Assert.assertNotNull(firstItemInList.getId());
-		Assert.assertNotNull(firstItemInList.getCreationDate());
+		Assert.assertNotNull(lastItemInList.getId());
+		Assert.assertNotNull(lastItemInList.getCreationDate());
+		Assert.assertEquals(lastItemInList.getCreationDate(), lastItemInList.getLastUpdateDate());
+		Assert.assertEquals(1, lastItemInList.getVersionNumber());
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_ThrowsException_WhenPathIdDoesNotExist() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item item = items.get(0);
+		final String NON_EXISTING_ID = "THIS-IS-AN-NON-EXISTING-ID";
+		item.setId(NON_EXISTING_ID);
+		Assertions.assertThrows(ResourceNotFoundException.class, () ->
+				itemService.updateItem(item.getId(), item)
+		);
+
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_ThrowsException_WhenPathIdIsNotEqualToRequestItemId() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 1);
+		Item item1 = items.get(0);
+		Item item2 = items.get(1);
+
+		Assertions.assertThrows(EntityValidationException.class, () ->
+				itemService.updateItem(item1.getId(), item2)
+		);
+
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_ThrowsException_WhenNameIsEmpty() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item item = items.get(0);
+		final String EMPTY_NAME = "";
+		item.setName(EMPTY_NAME);
+		Assertions.assertThrows(EntityValidationException.class, () ->
+				itemService.updateItem(item.getId(), item)
+		);
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_ThrowsException_WhenNameIsNull() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item item = items.get(0);
+		item.setName(null);
+		Assertions.assertThrows(EntityValidationException.class, () ->
+				itemService.updateItem(item.getId(), item)
+		);
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_ThrowsException_WhenAttributeKeyIsEmpty() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item item = items.get(0);
+		item.setAttributes(ImmutableMap.of("", "value"));
+		Assertions.assertThrows(EntityValidationException.class, () ->
+				itemService.updateItem(item.getId(), item)
+		);
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_ThrowsException_WhenAttributeKeyIsBlank() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item item = items.get(0);
+		item.setAttributes(ImmutableMap.of(" ", "value"));
+		Assertions.assertThrows(EntityValidationException.class, () ->
+				itemService.updateItem(item.getId(), item)
+		);
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_DoesNotChangeVersion_WhenItemHasNotChanged() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item selectedItem = items.get(0);
+		Item item = new Item();
+		item.setId(selectedItem.getId());
+		item.setName(selectedItem.getName());
+		item.setAttributes(selectedItem.getAttributes());
+
+		Item updatedItem = itemService.updateItem(item.getId(), item);
+		Assert.assertEquals(1, updatedItem.getVersionNumber());
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_UpdateItem_and_CreateVersion_WhenRequestValid() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item selectedItem = items.get(0);
+
+		final String UPDATED_ITEM_NAME = "Hello Luke";
+		Item item = new Item(UPDATED_ITEM_NAME, selectedItem.getAttributes());
+		item.setId(selectedItem.getId());
+
+		Assert.assertNotEquals(UPDATED_ITEM_NAME, selectedItem.getName());
+		Item updatedItem = itemService.updateItem(item.getId(), item);
+		Assert.assertEquals(2, updatedItem.getVersionNumber());
+		Assert.assertEquals(UPDATED_ITEM_NAME, updatedItem.getName());
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void updateItem_UpdateItemAttributes_WhenRequestValid() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item selectedItem = items.get(0);
+
+		final Map<String, String> UPDATED_ATTRIBUTES = ImmutableMap.of("year", "2020");
+		Item item = new Item(selectedItem.getName(), UPDATED_ATTRIBUTES);
+		item.setId(selectedItem.getId());
+
+		Assert.assertNotEquals(UPDATED_ATTRIBUTES, selectedItem.getAttributes());
+		Item updatedItem = itemService.updateItem(item.getId(), item);
+		Assert.assertEquals(UPDATED_ATTRIBUTES, updatedItem.getAttributes());
+		cleanItemsRepo();
+	}
+
+	@Test
+	public void getItemVersions_ReturnsHistoryOfChangesInDescOrder() throws InterruptedException {
+		cleanItemsRepo();
+		initItemsRepo();
+		List<Item> items = itemService.getItems();
+		Assert.assertTrue(items.size() > 0);
+		Item selectedItem = items.get(0);
+		final String ITEM_NAME_VERSION_1 = selectedItem.getName();
+		final String ITEM_NAME_VERSION_2 = "Hello Luke";
+		final String ITEM_NAME_VERSION_3 = "Hello Behnaz";
+
+		Thread.sleep(1000);
+		Item item = new Item(ITEM_NAME_VERSION_2);
+		item.setId(selectedItem.getId());
+		itemService.updateItem(item.getId(), item);
+
+		Thread.sleep(1000);
+		item = new Item(ITEM_NAME_VERSION_3);
+		item.setId(selectedItem.getId());
+		itemService.updateItem(item.getId(), item);
+
+		List<ItemVersion> versions = itemService.getItemVersions(item.getId());
+		Assert.assertEquals(3, versions.size());
+		ItemVersion firstVersionInList = versions.get(0);
+		ItemVersion secondVersionInList = versions.get(1);
+		ItemVersion thirdVersionInList = versions.get(2);
+		Assert.assertEquals(ITEM_NAME_VERSION_3, firstVersionInList.getName());
+		Assert.assertTrue(firstVersionInList.getVersionDate().toInstant().isAfter((secondVersionInList.getVersionDate().toInstant())));
+		Assert.assertTrue(firstVersionInList.getVersionNumber() > secondVersionInList.getVersionNumber());
+		Assert.assertEquals(ITEM_NAME_VERSION_2, secondVersionInList.getName());
+		Assert.assertTrue(secondVersionInList.getVersionDate().toInstant().isAfter((thirdVersionInList.getVersionDate().toInstant())));
+		Assert.assertTrue(secondVersionInList.getVersionNumber() > thirdVersionInList.getVersionNumber());
+		Assert.assertEquals(ITEM_NAME_VERSION_1, thirdVersionInList.getName());
 		cleanItemsRepo();
 	}
 
@@ -90,8 +279,8 @@ public class ItemServiceTest {
 
 	private void initItemsRepo() throws InterruptedException {
 		Item item1 = new Item("Item 1", ImmutableMap.of("year", "2019",
-		                                                "color", "black",
-		                                                "size", "S"));
+				"color", "black",
+				"size", "S"));
 
 		itemService.createItem(item1);
 		Thread.sleep(1000);


### PR DESCRIPTION
Add the ability to update existing items, keep previous versions of the item and show the versions. 

### Back-End
**Add ItemVersion** to the domain to keep an immutable copy of the item with the following fields:
-	versionNumber: int – version number
-	versionDate: Date – version creation date
-	name: String – item name
-	attributes: Map<String, String> - immutable copy of item attributes

Keeping an immutable copy of item guarantees that backed-up data stay unchanged. In addition, keeping versions in a separate entity makes their management easier and creates a meaningful relation between item and its versions. Especially, while mapping the entities to the database tables it is more efficient to have separate tables for items and their versions because of the following reasons: firstly, the size of the Item table dose not grow very fast and version_item table can be managed and scaled separately. Secondly, versions can be retrieved faster in comparison with the approach in which all items and their versions are kept in the same table. Thirdly, we can grant only select and insert permission on the version_item table to prevent accidental updates.

**Changes made on Item:**

-	Add versionNumber field to show the most recent version number.
-	Add lastUpdateDate field to show the last time the item has got updated. 
-	Add versions Deque<ItemVersion> field to keep track of item’s versions in a descending order based on their creation date. It is annotated with @JsonIgnore to prevent sending versions information while fetching items. When class is turned to a table entity this filed should have a one-to-many relation with ItemVersion and in order to improve performance its fetch parameter should be set to Lazy.

**Changes made on ItemService:**

-	Add Item updateItem(String id, Item item) method : to update the item with the requested id
-	List<ItemVersion> getItemVersions(String itemId) method: to return a list of item versions for the requested itemId 

**Changes made on ItemServiceImpl:**

-	Change items type from List<Item> to Map<String, Item> to access items faster
-	Change save method to create a version of item on save
-	Add getItem method to retrieve item with the requested itemId or throw exception if item not found
-	Add isNewVersion method to check whether the received item is different from the current version of item by checking its name and attributes. 
-	Add updateItem method to update the item. 
  --	checks item validity
  --	get the current version
  --	if the received item is a new version 
---	updates current item name and attributes
---	set lastUpdateDate of item 
---	save the current item as a new version
--	if there is received item is the same as the current one, return the current one without creating a new version
-	Add getItemVersions method to return list of item versions which belong to the item with the requested itemId 

**Changes made on ItemController:**

-	Add updateItem method, `Put /items/{itemId}`
-	Add getItemVersions method, `Get /items/{itemId}/versions `

### Front-End

**Changes made on Items**

-	Change Item interface, add id (optional) property; this field is null when posting a new item
-	Add ItemVersion interface which extends the Item interface with two fields: versionNumber and versionDate
-	Add async function putItem to update item and return a Promise of type Item 
-	Add async function getItemVersions to get all versions of item and return a Promise of  type ItemVersion[]

**Add item-version-card module**  to show versions details

**Changes made on item-card module**

-	Add update section to show item in a edit mode 
-	Add versions sections to show versions of item

**Changes made on add-items-dialog**

-	Add bindable item property to receive an item; on bind initialize the component with that item and set mode to edit, isEditMode = true
-	Add updateItem method to call update and pass the changed values  
-	Add saveItem method to call addItem or updateItem based on isEditMode 
-	Add cancel method to exist edit mode and inform its parent to cancel edit operation

### Suggestions

**Back-end:**

-	Add categories to group related items together
-	Add Spring Data JPA and implement data access layer to persist data permanently
-	Add Spring Data REST to create RESTful endpoints automatically based on repositories
-	Add pagination to getItems and getItemVersions
-	Add search ability to find items by their names or their attributes 
-	Add Spring Security to secure the application for example by
--	Enabling SSL (HTTPS) support
--	Adding user entity and relate items to their users; ensuring that each user can only access, update, and delete its own items by using access tokens, JWT. 
--	Assign users to groups and give users permission to manipulate only items that belong to their groups
--	Enable caching to improve performance, to cache items and itemVersions

**Front-end:**

-	Rename the add-items-dialog module to something like item-form since this module handle both adding and editing items
-	Use state management, have a single store approach
-	Add pagination to items and item versions lists
-	Add search ability
-	Add the ability to restore item to previous versions
-	Add the ability to create new items based on existing items
